### PR TITLE
Feat add bmsst to timeseries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,5 +30,5 @@ Suggests:
 License: EUPL
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Config/testthat/edition: 3

--- a/R/build_jabba.R
+++ b/R/build_jabba.R
@@ -57,6 +57,7 @@
 #' @param qA_bounds Defines lower and upper bounds for q of auxiliary data type effort 
 #' @param harvest.label = c("Hmsy","Fmsy")[2], # choose label preference H/Hmsy versus Fmsy
 #' @param catch.metric  "(t)" # Define catch input metric e.g. (tons) "000 t" 
+#' @param bfrac the amount to reduce BMSY by for overfished reference point. Default value is 1, for MSST, use `bfrac` = 1-M
 #' @param verbose option show cat comments
 #' @return List to be used as data input to JABBA JAGS model.
 #' @export
@@ -119,6 +120,7 @@ build_jabba <- function(
   # Settings
   harvest.label = c("Hmsy","Fmsy")[2], # choose label preference H/Hmsy versus Fmsy
   catch.metric = "(t)", # Define catch input metric e.g. (tons) "000 t" etc
+  bfrac = 1,
   verbose=TRUE
 ){
   
@@ -476,15 +478,15 @@ if(!is.null(rad.prior)){
                      nq=nq,nvar=nvar,sigma.fixed=ifelse(sigma.proc==TRUE,0,sigma.proc),
                      sets.var=sets.var, sets.q=sets.q,Plim=Plim,slope.HS=slope.HS,
                      nTAC=nTAC,pyrs=pyrs,TAC=TAC,igamma = igamma,stI=stI,pen.P = rep(0,n.years) ,pen.bk = rep(0,n.years),proc.pen=0,K.pen = 0,
-                     obs.pen = rep(0,nvar),P_bound=P_bound,q_bounds=q_bounds,sigmaobs_bound=sigmaobs_bound,sigmaproc_bound=sigmaproc_bound,K_bounds=K_bounds,mu.m=m,b.yr=b.yr, b.pr = b.pr)
-                     params <- c("K","r", "q", "psi","sigma2", "tau2","m","Hmsy","SBmsy", "MSY", "BtoBmsy","HtoHmsy","Overfishing_ind","CPUE","Ihat","Proc.Dev","P","SB","H","prP","prBtoBmsy","prHtoHmsy","prOverfishing_ind","TOE", "rad")
+                     obs.pen = rep(0,nvar),P_bound=P_bound,q_bounds=q_bounds,sigmaobs_bound=sigmaobs_bound,sigmaproc_bound=sigmaproc_bound,K_bounds=K_bounds,mu.m=m,b.yr=b.yr, b.pr = b.pr,bfrac=bfrac)
+                     params <- c("K","r", "q", "psi","sigma2", "tau2","m","Hmsy","SBmsy", "MSY", "BtoBmsy","BtoBfrac","HtoHmsy","Overfishing_ind","CPUE","Ihat","Proc.Dev","P","SB","H","prP","prBtoBmsy","prHtoHmsy","prBtoBfrac", "prOverfishing_ind","TOE", "rad")
   }else{
     surplus.dat = list(N=n.years, TC = TC,I=CPUE,SE2=se2,r.pr=r.pr,psi.pr=psi.pr,K.pr = K.pr,
                      nq=nq,nI = nI,nvar=nvar,nran.q=nran.q,sigma.fixed=ifelse(sigma.proc==TRUE,0,sigma.proc),
                      sets.var=sets.var, sets.q=sets.q,cpue_lambda=cpue_lambda,Plim=Plim,slope.HS=slope.HS,
                      nTAC=nTAC,pyrs=pyrs,TAC=TAC,igamma = igamma,stI=stI,pen.P = rep(0,n.years) ,pen.bk = rep(0,n.years),proc.pen=0,K.pen = 0,
-                     obs.pen = rep(0,nvar),P_bound=P_bound,q_bounds=q_bounds,sigmaobs_bound=sigmaobs_bound,sigmaproc_bound=sigmaproc_bound,K_bounds=K_bounds,mu.m=m,b.yr=b.yr, b.pr = b.pr)
-    params <- c("K","r", "q", "psi","sigma2", "tau2","m","Hmsy","SBmsy", "MSY", "BtoBmsy","HtoHmsy","Overfishing_ind","CPUE","Ihat","Proc.Dev","P","SB","H","prP","prBtoBmsy","prHtoHmsy","prOverfishing_ind","TOE")
+                     obs.pen = rep(0,nvar),P_bound=P_bound,q_bounds=q_bounds,sigmaobs_bound=sigmaobs_bound,sigmaproc_bound=sigmaproc_bound,K_bounds=K_bounds,mu.m=m,b.yr=b.yr, b.pr = b.pr,bfrac=bfrac)
+    params <- c("K","r", "q", "psi","sigma2", "tau2","m","Hmsy","SBmsy", "MSY", "BtoBmsy","HtoHmsy","BtoBfrac","Overfishing_ind","CPUE","Ihat","Proc.Dev","P","SB","H","prP","prBtoBmsy","prHtoHmsy","prBtoBfrac","prOverfishing_ind","TOE")
   }
   
   

--- a/R/fit_jabba.R
+++ b/R/fit_jabba.R
@@ -261,7 +261,7 @@ fit_jabba = function(jbinput,
   catch.temp = matrix(rep(catch[,2],each=nrow(posteriors$SB)),ncol=nrow(jbinput$data$catch),nrow=nrow(posteriors$SB))
   #JS added Overfishing ref point below
   yrdim = length(years)
-  Stock_trj = array(data=NA,dim=c(yrdim,3,9),dimnames = list(years,c("mu","lci","uci"),c("B","F","BBmsy","FFmsy","Overfishing_ind","BB0","procB","SPt","BtoBfrac"))) 
+  Stock_trj = array(data=NA,dim=c(yrdim,3,9),dimnames = list(years,c("mu","lci","uci"),c("B","F","BBmsy","FFmsy","Overfishing_ind","BB0","procB","BBfrac","SPt"))) 
   for(i in 1:3){
     Stock_trj[,i,] =  cbind(t(apply(posteriors$SB[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i],
                             t(apply(posteriors$H[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i],
@@ -270,9 +270,8 @@ fit_jabba = function(jbinput,
                             t(apply(posteriors$Overfishing_ind[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i],
                             t(apply(posteriors$P[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i],
                             t(apply(posteriors$Proc.Dev[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i],
-                            t(cbind(rep(0,3),apply(posteriors$SB[,-1]-posteriors$SB[,-ncol(posteriors$SB)]+catch.temp[,-ncol(posteriors$SB)],2,quantile,c(0.5,0.025,0.975)))[,1:yrdim])[,i],
-                            t(apply(posteriors$BtoBfrac[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i]
-
+                            t(apply(posteriors$BtoBfrac[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i],
+                            t(cbind(rep(0,3),apply(posteriors$SB[,-1]-posteriors$SB[,-ncol(posteriors$SB)]+catch.temp[,-ncol(posteriors$SB)],2,quantile,c(0.5,0.025,0.975)))[,1:yrdim])[,i]
     )
     
   }

--- a/R/fit_jabba.R
+++ b/R/fit_jabba.R
@@ -261,7 +261,7 @@ fit_jabba = function(jbinput,
   catch.temp = matrix(rep(catch[,2],each=nrow(posteriors$SB)),ncol=nrow(jbinput$data$catch),nrow=nrow(posteriors$SB))
   #JS added Overfishing ref point below
   yrdim = length(years)
-  Stock_trj = array(data=NA,dim=c(yrdim,3,8),dimnames = list(years,c("mu","lci","uci"),c("B","F","BBmsy","FFmsy","Overfishing_ind","BB0","procB","SPt"))) 
+  Stock_trj = array(data=NA,dim=c(yrdim,3,9),dimnames = list(years,c("mu","lci","uci"),c("B","F","BBmsy","FFmsy","Overfishing_ind","BB0","procB","SPt","BtoBfrac"))) 
   for(i in 1:3){
     Stock_trj[,i,] =  cbind(t(apply(posteriors$SB[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i],
                             t(apply(posteriors$H[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i],
@@ -270,7 +270,9 @@ fit_jabba = function(jbinput,
                             t(apply(posteriors$Overfishing_ind[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i],
                             t(apply(posteriors$P[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i],
                             t(apply(posteriors$Proc.Dev[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i],
-                            t(cbind(rep(0,3),apply(posteriors$SB[,-1]-posteriors$SB[,-ncol(posteriors$SB)]+catch.temp[,-ncol(posteriors$SB)],2,quantile,c(0.5,0.025,0.975)))[,1:yrdim])[,i]
+                            t(cbind(rep(0,3),apply(posteriors$SB[,-1]-posteriors$SB[,-ncol(posteriors$SB)]+catch.temp[,-ncol(posteriors$SB)],2,quantile,c(0.5,0.025,0.975)))[,1:yrdim])[,i],
+                            t(apply(posteriors$BtoBfrac[,1:yrdim],2,quantile,c(0.5,0.025,0.975)))[,i]
+
     )
     
   }

--- a/R/jabba2jags.R
+++ b/R/jabba2jags.R
@@ -273,6 +273,7 @@ cat("
     for (t in 1:N)  # Overfishing status given state-dependent rule
     {
     Overfishing_ind[t]<-ifelse(BtoBmsy[t]>0.866, H[t]/(Hmsy),  H[t]/((Hmsy*SB[t])/(0.866*SBmsy)))
+     BtoBfrac[t] <- SB[t]/(SBmsy*bfrac)
     }
 
 
@@ -593,6 +594,7 @@ cat("
       prH[t,i] <- TAC[t,i]/prB[t,i]
       prHtoHmsy[t,i] <- prH[t,i]/Hmsy
       prBtoBmsy[t,i] <- prB[t,i]/SBmsy
+      prBtoBfrac[t,i] <- prB[t,i]/(SBmsy*bfrac)
       prOverfishing_ind[t,i]<-ifelse(prBtoBmsy[t,i]>0.866, prH[t,i]/(Hmsy),  prH[t,i]/((Hmsy*prB[t,i])/(0.866*SBmsy)))
       }}
       ",append=TRUE)} else {
@@ -605,6 +607,8 @@ cat("
             prHtoHmsy <- 1
             prP <- 1
             prBtoBmsy <- 1
+            prBtoBfrac <- 1
+            prOverfishing_ind <- 1
             ", append=TRUE)}
   
   cat("

--- a/R/jabba_plots.R
+++ b/R/jabba_plots.R
@@ -1531,7 +1531,7 @@ jabba_plots = function(jabba,output.dir = getwd(),as.png=TRUE,statusplot ="kobe"
 #' jbplot_retro(hc,forecast=TRUE) # with retro forecasting
 #' }
 
-jbplot_retro <- function(hc,type=c("B","F","BBmsy","FFmsy","procB","SP"),forecast=FALSE,ylabs=NULL,
+jbplot_retro <- function(hc,type=c("B","F","BBmsy","FFmsy","procB","BBfrac","SP"),forecast=FALSE,ylabs=NULL,
                          add=F,output.dir=getwd(),as.png=FALSE,single.plots=add,width=NULL,height=NULL,xlim=NULL,cols=NULL,legend.loc="topright",verbose=TRUE){
   
   hc.ls = hc 
@@ -1553,16 +1553,16 @@ jbplot_retro <- function(hc,type=c("B","F","BBmsy","FFmsy","procB","SP"),forecas
   
   if(verbose)cat(paste0("\n","><> jbplot_retro() - retrospective analysis <><","\n"))
   if(add) single.plots=TRUE
-  if(single.plots==F) type=c("B","F","BBmsy","FFmsy","procB","SP")
+  if(single.plots==F) type=c("B","F","BBmsy","FFmsy","procB","BBfrac","SP")
   
-  if(is.null(ylabs)) ylabs = c(paste("Biomass",hc$settings$catch.metric),"Fishing mortality F",expression(B/B[MSY]),expression(F/F[MSY]),expression(B/B[0]),"Process Deviations",paste("Surplus Production",hc$settings$catch.metric))
+  if(is.null(ylabs)) ylabs = c(paste("Biomass",hc$settings$catch.metric),"Fishing mortality F",expression(B/B[MSY]),expression(F/F[MSY]),expression(B/B[0]),"Process Deviations",expression(B/B[MSST]), paste("Surplus Production",hc$settings$catch.metric))
   retros = unique(peels)
   runs= hc$timeseries$mu$level
   years= hc$yr
   nyrs = length(years)
   if(is.null(cols)) cols = c("black",ss3col(length(peels)-1))
   if(is.null(xlim)){xlim = range(years)}
-  FRP.rho = c("B","F", "Bmsy", "Fmsy", "procB","MSY")  
+  FRP.rho = c("B","F", "Bmsy", "Fmsy", "procB","Bmsst","MSY")  
   rho = data.frame(mat.or.vec(length(retros)-1,length(FRP.rho)))
   colnames(rho) = FRP.rho
   fcrho = rho
@@ -1578,14 +1578,14 @@ jbplot_retro <- function(hc,type=c("B","F","BBmsy","FFmsy","procB","SP"),forecas
       
       if(as.png==TRUE | add==FALSE) par(Par)
       
-      j = which(c("B","F","BBmsy","FFmsy","BB0","procB","SP")%in%type[k])
+      j = which(c("B","F","BBmsy","FFmsy","BB0","procB","BBfrac","SP")%in%type[k])
       
       
-      if(type[k]%in%c("B","F","BBmsy","FFmsy","procB")){
-        y = hc$timeseries$mu[,j+2]
-        ref = hc$timeseries$mu[runs%in%retros[1],j+2]
-        ylc = hc$timeseries$lci[runs%in%retros[1],j+2]
-        yuc = hc$timeseries$uci[runs%in%retros[1],j+2]
+      if(type[k]%in%c("B","F","BBmsy","FFmsy","procB","BBfrac")){
+        y = hc$timeseries$mu[,type]
+        ref = hc$timeseries$mu[runs%in%retros[1],type]
+        ylc = hc$timeseries$lci[runs%in%retros[1],type]
+        yuc = hc$timeseries$uci[runs%in%retros[1],type]
         if(type[k]=="procB") ylim=c(-max(y[years>=xlim[1] & years<=xlim[2]],yuc[years>=xlim[1] & years<=xlim[2]])
                                     ,max(y[years>=xlim[1] & years<=xlim[2]],yuc[years>=xlim[1] & years<=xlim[2]]))
         if(!type[k]=="procB") ylim=c(0,max(y[years>=xlim[1] & years<=xlim[2]],yuc[years>=xlim[1] & years<=xlim[2]]))
@@ -1608,7 +1608,7 @@ jbplot_retro <- function(hc,type=c("B","F","BBmsy","FFmsy","procB","SP"),forecas
             }
           }
         }
-        if(type[k]%in%c("BBmsy","FFmsy")) abline(h=1,lty=2)
+        if(type[k]%in%c("BBmsy","FFmsy","BBfrac")) abline(h=1,lty=2)
         if(type[k]%in%c("procB")) abline(h=0,lty=2)
       } 
       else {
@@ -1638,14 +1638,14 @@ jbplot_retro <- function(hc,type=c("B","F","BBmsy","FFmsy","procB","SP"),forecas
     par(Par)
     for(k in 1:length(type)){
       
-      j = which(c("B","F","BBmsy","FFmsy","BB0","procB","SP")%in%type[k])
+      j = which(c("B","F","BBmsy","FFmsy","BB0","procB","BBfrac","SP")%in%type[k])
       
       
-      if(type[k]%in%c("B","F","BBmsy","FFmsy","procB")){
-        y = hc$timeseries$mu[,j+2]
-        ref = hc$timeseries$mu[runs%in%retros[1],j+2]
-        ylc = hc$timeseries$lci[runs%in%retros[1],j+2]
-        yuc = hc$timeseries$uci[runs%in%retros[1],j+2]
+      if(type[k]%in%c("B","F","BBmsy","FFmsy","procB","BBfrac")){
+        y = hc$timeseries$mu[,type]
+        ref = hc$timeseries$mu[runs%in%retros[1],type]
+        ylc = hc$timeseries$lci[runs%in%retros[1],type]
+        yuc = hc$timeseries$uci[runs%in%retros[1],type]
         if(type[k]=="procB") ylim=c(-max(y[years>=xlim[1] & years<=xlim[2]],yuc[years>=xlim[1] & years<=xlim[2]])
                                     ,max(y[years>=xlim[1] & years<=xlim[2]],yuc[years>=xlim[1] & years<=xlim[2]]))
         if(!type[k]=="procB") ylim=c(0,max(y[years>=xlim[1] & years<=xlim[2]],yuc[years>=xlim[1] & years<=xlim[2]]))
@@ -1667,7 +1667,7 @@ jbplot_retro <- function(hc,type=c("B","F","BBmsy","FFmsy","procB","SP"),forecas
             }
           }
         }
-        if(type[k]%in%c("BBmsy","FFmsy")) abline(h=1,lty=2)
+        if(type[k]%in%c("BBmsy","FFmsy","BBfrac")) abline(h=1,lty=2)
         if(type[k]%in%c("procB")) abline(h=0,lty=2)
         if(single.plots==TRUE | k==1 )  legend(legend.loc,paste(years[nyrs-retros]),col=cols,bty="n",cex=0.7,pt.cex=0.7,lwd=c(2,rep(1.5,length(retros))))
         if(!forecast) legend("top",legend=bquote(rho == .(round(mean(rho[,k]),2))) ,bty="n",x.intersp=-0.2,y.intersp=-0.3,cex=0.8)

--- a/man/build_jabba.Rd
+++ b/man/build_jabba.Rd
@@ -60,6 +60,7 @@ build_jabba(
   qA_bounds = c(10^-30, 1000),
   harvest.label = c("Hmsy", "Fmsy")[2],
   catch.metric = "(t)",
+  bfrac = 1,
   verbose = TRUE
 )
 }
@@ -167,6 +168,8 @@ VARIANCE options}
 \item{harvest.label}{= c("Hmsy","Fmsy")[2], # choose label preference H/Hmsy versus Fmsy}
 
 \item{catch.metric}{"(t)" # Define catch input metric e.g. (tons) "000 t"}
+
+\item{bfrac}{the amount to reduce BMSY by for overfished reference point. Default value is 1, for MSST, use `bfrac` = 1-M}
 
 \item{verbose}{option show cat comments}
 


### PR DESCRIPTION
Added a B/BBfrac calculation into the jabba2jags code. BBfrac is the fraction of BMSY, and can be applied for cases when you need to use a different reference point than BMSY. I added the argument `bfrac` to `build_jabba()` function where users can specify the proportion of BMSY, e.g. for BMSST, `bfrac` = 1-M so if M = .134, `bfrac = 0.866`. The default value is 1, so if you do not specify bfrac, the timeseries of B/Bfrac will be the same as B/BMSY. In `jbplot_retro()` I added the option of "BBfrac" for `type`. 